### PR TITLE
Add a space after a comma to handle proc_info() properly

### DIFF
--- a/generate-bsd-syscalls.py
+++ b/generate-bsd-syscalls.py
@@ -6,6 +6,7 @@ import shutil
 import string
 import datetime
 import json
+import re
 
 
 # Make a temporary file of BSD syscalls without any additional shit around
@@ -63,6 +64,7 @@ def bsd_list_generate():
 			continue
 
 		line = line.replace(" (", "(")
+		line = re.sub(r',([^\s])', r', \1', line)
 		elems = line.split()
 
 		# Syscall ID


### PR DESCRIPTION
Arguments of BSD syscall 336 proc_info() are wrong on the current BSD syscall list: https://sigsegv.pl/osx-bsd-syscalls/

Because the arguments are not separated by `,(space)` but just `,` on the `AUE_PROCINFO` line in `bsd/kern/syscalls.master`.